### PR TITLE
Add entry for SR due dates for signs and markings

### DIFF
--- a/config/scripts.yml
+++ b/config/scripts.yml
@@ -847,10 +847,21 @@ finance_units:
   job: true
   path: ../finance-scraper
   source: controllers_office
-sr_due_date:
+sr_due_date_data_tracker:
   args:
   - data_tracker_prod
   cron: '07 4 * * *'
+  destination: knack
+  enabled: true
+  filename: sr_due_date.py
+  init_func: main
+  job: true
+  path: ../atd-data-publishing/transportation-data-publishing/data_tracker
+  source: knack
+sr_due_date_signs_markings:
+  args:
+  - signs_markings_prod
+  cron: '11 4 * * *'
   destination: knack
   enabled: true
   filename: sr_due_date.py

--- a/config/scripts.yml
+++ b/config/scripts.yml
@@ -905,16 +905,6 @@ signal_pms_postgre_to_knack:
   job: true
   path: ../atd-data-publishing/transportation-data-publishing/data_tracker
   source: postgrest
-waze_archive_postgre:
-  cron: "*/5 * * * *"
-  destination: postgrest
-  docker_cmd: default
-  enabled: true
-  filename: waze_psql.py
-  init_func: main
-  job: true
-  path: ../waze-archive
-  source: waze_endpoint
 dockless_trips:
   args:
   - dockless_trips
@@ -1012,15 +1002,3 @@ dockless_pt_poly:
   job: true
   path: ../transportation-dockless-processing
   source: mds
-email_service_request:
-  args:
-    - dts_portal_prod
-  cron: '*/1 * * * *'
-  destination: dts-portal
-  enabled: true
-  filename: email_service_request
-  init_func: main
-  job: true
-  path: ../transportation-data-service/
-  source: gmail
-


### PR DESCRIPTION
This patch adds a script deployment for `sr_due_date.py` for the Signs & Markings Operations app, and updates the script namespace to distinguish between the instance for Data Tracker vs Signs & Markings app. I've also removed two broken scripts from our deployment, pending further attention: `waze_archive_postgre` and `email_service_request`.

It is dependent upon updates to `atd-data-publishing` via [#283](https://github.com/cityofaustin/atd-data-publishing/pull/238). 