### PR TITLE
Add args to atd-service-bot config

### DIFF
--- a/config/scripts.yml
+++ b/config/scripts.yml
@@ -1016,6 +1016,9 @@ dockless_pt_poly:
   source: mds
 dts_to_github_issue:
   docker_cmd: atd-service-bot
+  args:
+  - -e
+  - prod
   cron: '*/1 * * * *'
   destination: github
   enabled: true


### PR DESCRIPTION
This PR adds required arguments to the config for the atd-service-bot script in `scripts.yml`.

Command from https://github.com/cityofaustin/atd-service-bot/pull/13:

`$ python intake.py -e prod`

