### PR TITLE
Set config for MMC dataset

### DIFF
--- a/config/scripts.yml
+++ b/config/scripts.yml
@@ -453,6 +453,22 @@ metadata_updater:
   job: true
   path: ../atd-data-publishing/transportation-data-publishing/data_tracker
   source: knack
+mmc_activities_socrata:
+  args:
+  - mmc_activities
+  - data_tracker_prod
+  - -d
+  - socrata
+  - --last_run_date
+  - "0"
+  cron: 30 2 * * *
+  destination: socrata
+  enabled: true
+  filename: knack_data_pub.py
+  init_func: main
+  job: true
+  path: ../atd-data-publishing/transportation-data-publishing/open_data
+  source: knack
 pole_attachments_agol:
   args:
   - pole_attachments


### PR DESCRIPTION
Closes part of https://github.com/cityofaustin/atd-data-tech/issues/1241

This PR adds the config to publish the new MMC activities dataset. I set the cron schedule to "At 2:30" since no other jobs run at that time.