### PR TITLE
Update handling of last_run_date arg

### DIFF
--- a/launch.py
+++ b/launch.py
@@ -81,9 +81,9 @@ class Script:
 
                     last_run_date = self.args[index]
 
-                    if not int(last_run_date):
+                    if int(last_run_date) == 0:
                         if self.job:
-                            last_run_date = self.job.most_recent()
+                            last_run_date = self.job.most_recent() or 0
                         else:
                             # when last_run_date is not provided set to 0 unix seconds
                             last_run_date = 0


### PR DESCRIPTION
This PR updates the handling of the `last_run_date` arg in `launch.py`. This update patches a bug where `0` was being interpreted as falsey and also adds a backup value of `0` in the case of a job not existing for a process yet.