### PR TITLE
Disable signals publisher

### DIFF
--- a/config/scripts.yml
+++ b/config/scripts.yml
@@ -609,38 +609,6 @@ signal_retiming:
   job: true
   path: ../atd-data-publishing/transportation-data-publishing/open_data
   source: knack
-signals_agol:
-  args:
-    - signals
-    - data_tracker_prod
-    - -d
-    - agol
-    - --last_run_date
-    - "0"
-  cron: 15 * * * *
-  destination: agol
-  enabled: true
-  filename: knack_data_pub.py
-  init_func: main
-  job: true
-  path: ../atd-data-publishing/transportation-data-publishing/open_data
-  source: knack
-signals_socrata:
-  args:
-    - signals
-    - data_tracker_prod
-    - -d
-    - socrata
-    - --last_run_date
-    - "0"
-  cron: 15 * * * *
-  destination: socrata
-  enabled: true
-  filename: knack_data_pub.py
-  init_func: main
-  job: true
-  path: ../atd-data-publishing/transportation-data-publishing/open_data
-  source: knack
 street_seg_updater:
   args:
     - data_tracker_prod


### PR DESCRIPTION
Disable the signals publisher. It's been replaced by atd-knack-services as described in [#4471](https://github.com/cityofaustin/atd-data-tech/issues/4471).